### PR TITLE
fix(ci): Sleep 10s before running integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "DATA_DIR=$(mktemp -d) c8 mocha",
-    "int-test": "mocha int-test/",
+    "int-test": "sleep 10s; mocha int-test/",
     "xo": "xo"
   },
   "repository": {


### PR DESCRIPTION
## Issues
Fixes #<insertIssue>

## Reviewer Suggestions
Where should the reviewer start?

## Additional Comments
Ensures sleep 10s before running integration tests to allow for service to go up.
